### PR TITLE
Add hidden field for the contact form widget

### DIFF
--- a/assets/content-forms.css
+++ b/assets/content-forms.css
@@ -2,6 +2,9 @@
     display: block;
     margin-top: 20px;
 }
+.ti-cf-module .content-form-field-hidden{
+    display: none;
+}
 .ti-cf-module input,
 .ti-cf-module textarea {
     width: 100%;

--- a/includes/widgets-admin/beaver/beaver_widget_base.php
+++ b/includes/widgets-admin/beaver/beaver_widget_base.php
@@ -34,11 +34,25 @@ abstract class Beaver_Widget_Base extends \FLBuilderModule {
 	public $default_data = array();
 
 	/**
+	 * Field types.
+	 *
+	 * @var array
+	 */
+	protected $field_types = array();
+
+	/**
 	 * Beaver_Widget_Base constructor.
 	 *
 	 * @param $data
 	 */
 	public function __construct( $data ) {
+
+		$this->field_types = array(
+			'text'     => esc_html__( 'Text', 'textdomain' ),
+			'email'    => esc_html__( 'Email', 'textdomain' ),
+			'textarea' => esc_html__( 'Textarea', 'textdomain' ),
+			'password' => esc_html__( 'Password', 'textdomain' ),
+		);
 
 		$this->run_hooks();
 
@@ -487,16 +501,7 @@ abstract class Beaver_Widget_Base extends \FLBuilderModule {
 			),
 		);
 
-		$fields_type =  array(
-			'text'     => esc_html__( 'Text', 'textdomain' ),
-			'email'    => esc_html__( 'Email', 'textdomain' ),
-			'textarea' => esc_html__( 'Textarea', 'textdomain' ),
-			'password' => esc_html__( 'Password', 'textdomain' ),
-		);
-		if( $this->get_type() === 'contact' ){
-			$fields_type['hidden'] = esc_html__( 'Hidden', 'textdomain' );
-		}
-
+		$fields_type =  $this->get_specific_field_types();
 		$repeater_fields = array(
 			'label'       => array(
 				'type'  => 'text',
@@ -550,14 +555,6 @@ abstract class Beaver_Widget_Base extends \FLBuilderModule {
 				),
 			),
 		);
-
-		if( $this->get_type() === 'contact' ){
-			$repeater_fields['hidden_value'] = array(
-				'type'        => 'textarea',
-				'label'       => esc_html__( 'Value', 'textdomain' ),
-				'description' => __( 'You can use the following magic tags to get additional information: {current_url}, {username}, {user_nice_name}, {user_type}, {user_email}', 'textdomain' ),
-			);
-		}
 
 		\FLBuilder::register_settings_form(
 			$this->get_type() . '_field',
@@ -971,4 +968,11 @@ abstract class Beaver_Widget_Base extends \FLBuilderModule {
 	 * @return array
 	 */
 	abstract function widget_default_values();
+
+	/**
+	 * Get allowed field types.
+	 *
+	 * @return array
+	 */
+	abstract function get_specific_field_types();
 }

--- a/includes/widgets-admin/beaver/beaver_widget_base.php
+++ b/includes/widgets-admin/beaver/beaver_widget_base.php
@@ -487,15 +487,13 @@ abstract class Beaver_Widget_Base extends \FLBuilderModule {
 			),
 		);
 
-
-		$form_type   = $this->get_type();
 		$fields_type =  array(
 			'text'     => esc_html__( 'Text', 'textdomain' ),
 			'email'    => esc_html__( 'Email', 'textdomain' ),
 			'textarea' => esc_html__( 'Textarea', 'textdomain' ),
 			'password' => esc_html__( 'Password', 'textdomain' ),
 		);
-		if( $form_type === 'contact' ){
+		if( $this->get_type() === 'contact' ){
 			$fields_type['hidden'] = esc_html__( 'Hidden', 'textdomain' );
 		}
 
@@ -551,12 +549,15 @@ abstract class Beaver_Widget_Base extends \FLBuilderModule {
 					'optional' => esc_html__( 'Optional', 'textdomain' ),
 				),
 			),
-			'hidden_value' => array(
+		);
+
+		if( $this->get_type() === 'contact' ){
+			$repeater_fields['hidden_value'] = array(
 				'type'        => 'textarea',
 				'label'       => esc_html__( 'Value', 'textdomain' ),
 				'description' => __( 'You can use the following magic tags to get additional information: {current_url}, {username}, {user_nice_name}, {user_type}, {user_email}', 'textdomain' ),
-			)
-		);
+			);
+		}
 
 		\FLBuilder::register_settings_form(
 			$this->get_type() . '_field',

--- a/includes/widgets-admin/beaver/beaver_widget_base.php
+++ b/includes/widgets-admin/beaver/beaver_widget_base.php
@@ -795,8 +795,7 @@ abstract class Beaver_Widget_Base extends \FLBuilderModule {
 				echo '<input type="password" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" ' . $required . '>';
 				break;
 			case 'hidden':
-				$hidden_field_value = $field['hidden_value'];
-				echo '<input type="hidden" value="' . esc_attr( $hidden_field_value ) . '" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '">';
+				echo '<input type="hidden" value="' . esc_attr( $field['hidden_value'] ) . '" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '">';
 				break;
 			default:
 				echo '<input type="text" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" ' . $required . ' ' . $placeholder . '">';

--- a/includes/widgets-admin/beaver/beaver_widget_base.php
+++ b/includes/widgets-admin/beaver/beaver_widget_base.php
@@ -487,6 +487,18 @@ abstract class Beaver_Widget_Base extends \FLBuilderModule {
 			),
 		);
 
+
+		$form_type   = $this->get_type();
+		$fields_type =  array(
+			'text'     => esc_html__( 'Text', 'textdomain' ),
+			'email'    => esc_html__( 'Email', 'textdomain' ),
+			'textarea' => esc_html__( 'Textarea', 'textdomain' ),
+			'password' => esc_html__( 'Password', 'textdomain' ),
+		);
+		if( $form_type === 'contact' ){
+			$fields_type['hidden'] = esc_html__( 'Hidden', 'textdomain' );
+		}
+
 		$repeater_fields = array(
 			'label'       => array(
 				'type'  => 'text',
@@ -499,11 +511,23 @@ abstract class Beaver_Widget_Base extends \FLBuilderModule {
 			'type'        => array(
 				'type'    => 'select',
 				'label'   => esc_html__( 'Type', 'textdomain' ),
-				'options' => array(
-					'text'     => esc_html__( 'Text' ),
-					'email'    => esc_html__( 'Email' ),
-					'textarea' => esc_html__( 'Textarea', 'textdomain' ),
-					'password' => esc_html__( 'Password', 'textdomain' ),
+				'options' => $fields_type,
+				'toggle'  => array(
+					'password' => array(
+						'fields' => array( 'placeholder', 'field_width', 'required', 'label' ),
+					),
+					'textarea' => array(
+						'fields' => array( 'placeholder', 'field_width', 'required', 'label' ),
+					),
+					'email' => array(
+						'fields' => array( 'placeholder', 'field_width', 'required', 'label' ),
+					),
+					'text' => array(
+						'fields' => array( 'placeholder', 'field_width', 'required', 'label' ),
+					),
+					'hidden' => array(
+						'fields' => array( 'hidden_value', 'label' ),
+					)
 				),
 			),
 			'field_width' => array(
@@ -527,6 +551,11 @@ abstract class Beaver_Widget_Base extends \FLBuilderModule {
 					'optional' => esc_html__( 'Optional', 'textdomain' ),
 				),
 			),
+			'hidden_value' => array(
+				'type'        => 'textarea',
+				'label'       => esc_html__( 'Value', 'textdomain' ),
+				'description' => __( 'You can use the following magic tags to get additional information: {current_url}, {username}, {user_nice_name}, {user_type}, {user_email}', 'textdomain' ),
+			)
 		);
 
 		\FLBuilder::register_settings_form(
@@ -767,6 +796,10 @@ abstract class Beaver_Widget_Base extends \FLBuilderModule {
 			case 'password':
 				echo '<input type="password" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" ' . $required . '>';
 				break;
+			case 'hidden':
+				$hidden_field_value = $field['hidden_value'];
+				echo '<input type="hidden" value="' . esc_attr( $hidden_field_value ) . '" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '">';
+				break;
 			default:
 				echo '<input type="text" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" ' . $required . ' ' . $placeholder . '">';
 				break;
@@ -840,6 +873,10 @@ abstract class Beaver_Widget_Base extends \FLBuilderModule {
 	 * @return bool
 	 */
 	private function maybe_render_field_label( $field_name, $field ) {
+		if ( $field['type'] === 'hidden' ){
+			return false;
+		}
+
 		$label = $field['label'];
 		if ( empty( $label ) ) {
 			return false;

--- a/includes/widgets-admin/beaver/class-themeisle-content-forms-beaver-contact.php
+++ b/includes/widgets-admin/beaver/class-themeisle-content-forms-beaver-contact.php
@@ -100,6 +100,11 @@ class Contact_Admin extends Beaver_Widget_Base {
 	 * @return array
 	 */
 	public function add_widget_repeater_fields( $fields ) {
+		$fields['hidden_value'] = array(
+			'type'        => 'textarea',
+			'label'       => esc_html__( 'Value', 'textdomain' ),
+			'description' => __( 'You can use the following magic tags to get additional information: {current_url}, {username}, {user_nice_name}, {user_type}, {user_email}', 'textdomain' ),
+		);
 		return $fields;
 	}
 
@@ -130,5 +135,16 @@ class Contact_Admin extends Beaver_Widget_Base {
 			),
 		) + $fields['fields'];
 		return $fields;
+	}
+
+	/**
+	 * Get specific field types.
+	 *
+	 * @return array
+	 */
+	function get_specific_field_types() {
+		$field_types = $this->field_types;
+		$field_types['hidden'] = esc_html__( 'Hidden', 'textdomain' );
+		return $field_types;
 	}
 }

--- a/includes/widgets-admin/beaver/class-themeisle-content-forms-beaver-newsletter.php
+++ b/includes/widgets-admin/beaver/class-themeisle-content-forms-beaver-newsletter.php
@@ -125,4 +125,13 @@ class Newsletter_Admin extends Beaver_Widget_Base {
 
 		return $fields;
 	}
+
+	/**
+	 * Get specific field types.
+	 *
+	 * @return array
+	 */
+	function get_specific_field_types() {
+		return $this->field_types;
+	}
 }

--- a/includes/widgets-admin/beaver/class-themeisle-content-forms-beaver-registration.php
+++ b/includes/widgets-admin/beaver/class-themeisle-content-forms-beaver-registration.php
@@ -129,4 +129,13 @@ class Registration_Admin extends Beaver_Widget_Base {
 
 		return $fields;
 	}
+
+	/**
+	 * Get specific field types.
+	 *
+	 * @return array
+	 */
+	function get_specific_field_types() {
+		return $this->field_types;
+	}
 }

--- a/includes/widgets-admin/elementor/contact_admin.php
+++ b/includes/widgets-admin/elementor/contact_admin.php
@@ -177,6 +177,28 @@ class Contact_Admin extends Elementor_Widget_Base {
 	 * @return bool
 	 */
 	function add_repeater_specific_fields( $repeater ) {
-		return false;
+		$repeater->add_control(
+			'hidden_value',
+			array(
+				'label'       => __( 'Value', 'textdomain' ),
+				'description' => __( 'You can use the following magic tags to get additional information: {current_url}, {username}, {user_nice_name}, {user_type}, {user_email}', 'textdomain' ),
+				'type'        => Controls_Manager::TEXTAREA,
+				'default'     => '',
+				'condition'   => array(
+					'type' => 'hidden',
+				),
+			)
+		);
+	}
+
+	/**
+	 * Specific field types for Contact form.
+	 *
+	 * @return array
+	 */
+	function get_specific_field_types() {
+		$field_types = $this->field_types;
+		$field_types['hidden'] = esc_html__( 'Hidden', 'textdomain' );
+		return $field_types;
 	}
 }

--- a/includes/widgets-admin/elementor/elementor_widget_base.php
+++ b/includes/widgets-admin/elementor/elementor_widget_base.php
@@ -24,6 +24,8 @@ use ThemeIsle\ContentForms\Form_Manager;
  */
 abstract class Elementor_Widget_Base extends Widget_Base {
 
+	protected $field_types = array();
+
 	/**
 	 * All the widgets that extends this class have the same category.
 	 *
@@ -55,6 +57,13 @@ abstract class Elementor_Widget_Base extends Widget_Base {
 	 * Register the controls for each Elementor Widget.
 	 */
 	protected function _register_controls() {
+		$this->field_types = array(
+			'text'     => __( 'Text', 'textdomain' ),
+			'password' => __( 'Password', 'textdomain' ),
+			'email'    => __( 'Email', 'textdomain' ),
+			'textarea' => __( 'Textarea', 'textdomain' ),
+		);
+
 		$this->register_form_fields();
 		$this->register_settings_controls();
 		$this->register_style_controls();
@@ -87,16 +96,7 @@ abstract class Elementor_Widget_Base extends Widget_Base {
 			)
 		);
 
-		$field_types = array(
-			'text'     => __( 'Text', 'textdomain' ),
-			'password' => __( 'Password', 'textdomain' ),
-			'email'    => __( 'Email', 'textdomain' ),
-			'textarea' => __( 'Textarea', 'textdomain' ),
-		);
-		if( $this->get_widget_type() === 'contact' ){
-			$field_types['hidden'] = esc_html__( 'Hidden', 'textdomain' );
-		}
-
+		$field_types = $this->get_specific_field_types();
 		$repeater->add_control(
 			'type',
 			array(
@@ -156,20 +156,6 @@ abstract class Elementor_Widget_Base extends Widget_Base {
 			)
 		);
 
-		if( $this->get_widget_type() === 'contact' ) {
-			$repeater->add_control(
-				'hidden_value',
-				array(
-					'label'       => __( 'Value', 'textdomain' ),
-					'description' => __( 'You can use the following magic tags to get additional information: {current_url}, {username}, {user_nice_name}, {user_type}, {user_email}', 'textdomain' ),
-					'type'        => Controls_Manager::TEXTAREA,
-					'default'     => '',
-					'condition'   => array(
-						'type' => 'hidden',
-					),
-				)
-			);
-		}
 		$this->add_repeater_specific_fields( $repeater );
 
 		$default_fields = $this->get_default_config();
@@ -1318,4 +1304,11 @@ abstract class Elementor_Widget_Base extends Widget_Base {
 	 * Add widget specific settings controls.
 	 */
 	abstract function add_specific_settings_controls();
+
+	/**
+	 * Get allowed field types.
+	 *
+	 * @return array
+	 */
+	abstract function get_specific_field_types();
 }

--- a/includes/widgets-admin/elementor/elementor_widget_base.php
+++ b/includes/widgets-admin/elementor/elementor_widget_base.php
@@ -81,15 +81,22 @@ abstract class Elementor_Widget_Base extends Widget_Base {
 				'type'         => Controls_Manager::SWITCHER,
 				'return_value' => 'required',
 				'default'      => '',
+				'condition' => array(
+					'type!' => 'hidden',
+				),
 			)
 		);
 
+		$form_type   = $this->get_type();
 		$field_types = array(
 			'text'     => __( 'Text', 'textdomain' ),
 			'password' => __( 'Password', 'textdomain' ),
 			'email'    => __( 'Email', 'textdomain' ),
 			'textarea' => __( 'Textarea', 'textdomain' ),
 		);
+		if( $form_type === 'contact' ){
+			$fields_type['hidden'] = esc_html__( 'Hidden', 'textdomain' );
+		}
 
 		$repeater->add_control(
 			'type',
@@ -123,6 +130,9 @@ abstract class Elementor_Widget_Base extends Widget_Base {
 					'25'  => '25%',
 				),
 				'default' => '100',
+				'condition' => array(
+					'type!' => 'hidden',
+				),
 			)
 		);
 
@@ -141,6 +151,22 @@ abstract class Elementor_Widget_Base extends Widget_Base {
 				'label'   => __( 'Placeholder', 'textdomain' ),
 				'type'    => Controls_Manager::TEXT,
 				'default' => '',
+				'condition' => array(
+					'type!' => 'hidden',
+				),
+			)
+		);
+
+		$repeater->add_control(
+			'hidden_value',
+			array(
+				'label'       => __( 'Value', 'textdomain' ),
+				'description' => __( 'You can use the following magic tags to get additional information: {current_url}, {username}, {user_nice_name}, {user_type}, {user_email}', 'textdomain' ),
+				'type'        => Controls_Manager::TEXTAREA,
+				'default'     => '',
+				'condition'   => array(
+					'type' => 'hidden',
+				),
 			)
 		);
 		$this->add_repeater_specific_fields( $repeater );
@@ -1155,6 +1181,10 @@ abstract class Elementor_Widget_Base extends Widget_Base {
 			case 'password':
 				echo '<input type="password" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" ' . $required . ' ' . $disabled . '>';
 				break;
+			case 'hidden':
+				$hidden_field_value = $field['hidden_value'];
+				echo '<input type="hidden" value="' . esc_attr( $hidden_field_value ) . '" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" ' . $disabled . '>';
+				break;
 			default:
 				echo '<input type="text" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" ' . $required . ' ' . $disabled . ' placeholder="' . esc_attr( $placeholder ) . '">';
 				break;
@@ -1221,6 +1251,9 @@ abstract class Elementor_Widget_Base extends Widget_Base {
 	 */
 	private function render_field_label( $field ) {
 
+		if ( $field['type'] === 'hidden' ) {
+			return false;
+		}
 		$settings      = $this->get_settings();
 		$display_label = $settings['hide_label'];
 		$field_id      = $field['_id'];

--- a/includes/widgets-admin/elementor/elementor_widget_base.php
+++ b/includes/widgets-admin/elementor/elementor_widget_base.php
@@ -87,15 +87,14 @@ abstract class Elementor_Widget_Base extends Widget_Base {
 			)
 		);
 
-		$form_type   = $this->get_type();
 		$field_types = array(
 			'text'     => __( 'Text', 'textdomain' ),
 			'password' => __( 'Password', 'textdomain' ),
 			'email'    => __( 'Email', 'textdomain' ),
 			'textarea' => __( 'Textarea', 'textdomain' ),
 		);
-		if( $form_type === 'contact' ){
-			$fields_type['hidden'] = esc_html__( 'Hidden', 'textdomain' );
+		if( $this->get_widget_type() === 'contact' ){
+			$field_types['hidden'] = esc_html__( 'Hidden', 'textdomain' );
 		}
 
 		$repeater->add_control(
@@ -157,18 +156,20 @@ abstract class Elementor_Widget_Base extends Widget_Base {
 			)
 		);
 
-		$repeater->add_control(
-			'hidden_value',
-			array(
-				'label'       => __( 'Value', 'textdomain' ),
-				'description' => __( 'You can use the following magic tags to get additional information: {current_url}, {username}, {user_nice_name}, {user_type}, {user_email}', 'textdomain' ),
-				'type'        => Controls_Manager::TEXTAREA,
-				'default'     => '',
-				'condition'   => array(
-					'type' => 'hidden',
-				),
-			)
-		);
+		if( $this->get_widget_type() === 'contact' ) {
+			$repeater->add_control(
+				'hidden_value',
+				array(
+					'label'       => __( 'Value', 'textdomain' ),
+					'description' => __( 'You can use the following magic tags to get additional information: {current_url}, {username}, {user_nice_name}, {user_type}, {user_email}', 'textdomain' ),
+					'type'        => Controls_Manager::TEXTAREA,
+					'default'     => '',
+					'condition'   => array(
+						'type' => 'hidden',
+					),
+				)
+			);
+		}
 		$this->add_repeater_specific_fields( $repeater );
 
 		$default_fields = $this->get_default_config();

--- a/includes/widgets-admin/elementor/newsletter_admin.php
+++ b/includes/widgets-admin/elementor/newsletter_admin.php
@@ -359,4 +359,13 @@ class Newsletter_Admin extends Elementor_Widget_Base {
 			}
 		}
 	}
+
+	/**
+	 * Specific field types for Newsletter form.
+	 *
+	 * @return array
+	 */
+	function get_specific_field_types() {
+		return $this->field_types;
+	}
 }

--- a/includes/widgets-admin/elementor/registration_admin.php
+++ b/includes/widgets-admin/elementor/registration_admin.php
@@ -181,4 +181,13 @@ class Registration_Admin extends Elementor_Widget_Base {
 			)
 		);
 	}
+
+	/**
+	 * Specific field types for Registration form.
+	 *
+	 * @return array
+	 */
+	function get_specific_field_types() {
+		return $this->field_types;
+	}
 }

--- a/includes/widgets-public/contact_public.php
+++ b/includes/widgets-public/contact_public.php
@@ -40,7 +40,6 @@ class Contact_Public extends Widget_Actions_Base {
 	 * @return array
 	 */
 	public function rest_submit_form( $return, $data, $widget_id, $post_id, $builder ) {
-
 		$settings        = $this->get_widget_settings( $widget_id, $post_id, $builder );
 		$success_message = array_key_exists( 'success_message', $settings ) && ! empty( $settings['success_message'] ) ? $settings['success_message'] : esc_html__( 'Your message has been sent!', 'textdomain' );
 		$error_message   = array_key_exists( 'error_message', $settings ) && ! empty( $settings['error_message'] ) ? $settings['error_message'] : esc_html__( 'We failed to send your message!', 'textdomain' );
@@ -66,7 +65,7 @@ class Contact_Public extends Widget_Actions_Base {
 			$key            = Form_Manager::get_field_key_name( $field );
 			$required_field = array_key_exists( 'requirement', $field ) ? $field['requirement'] : ( array_key_exists( 'required', $field ) ? $field['required'] : '' );
 
-			if ( 'required' === $required_field && empty( $data[ $key ] ) ) {
+			if ( 'required' === $required_field && empty( $data[ $key ] ) && 'hidden' !== $field['type'] ) {
 				$return['message'] = sprintf( esc_html__( 'Missing %s', 'textdomain' ), $key );
 				return $return;
 			}
@@ -77,7 +76,7 @@ class Contact_Public extends Widget_Actions_Base {
 			}
 
 			if( 'hidden' === $field['type'] ){
-				$data[ $key ] = $this->parse_hidden_text( $data[ $key ] );
+				$data[ $key ] = $this->parse_hidden_text( $data[ $key ], $post_id );
 			}
 		}
 

--- a/includes/widgets-public/contact_public.php
+++ b/includes/widgets-public/contact_public.php
@@ -75,6 +75,10 @@ class Contact_Public extends Widget_Actions_Base {
 				$return['message'] = esc_html__( 'Invalid email.', 'textdomain' );
 				return $return;
 			}
+
+			if( 'hidden' === $field['type'] ){
+				$data[ $key ] = $this->parse_hidden_text( $data[ $key ] );
+			}
 		}
 
 		$from = isset( $data['email'] ) ? $data['email'] : null;

--- a/includes/widgets-public/widget_actions_base.php
+++ b/includes/widgets-public/widget_actions_base.php
@@ -162,7 +162,7 @@ abstract class Widget_Actions_Base {
 			$hidden_value = str_replace( '{user_type}', implode(', ', $user_info->roles), $hidden_value );
 			$hidden_value = str_replace( '{user_email}',  $user_info->user_email, $hidden_value );
 		} else {
-			$replacement = __( 'Could not retrieve the info because the user is not logged id', 'textdomain' );
+			$replacement = __( 'Could not retrieve the info because the user is not logged in.', 'textdomain' );
 			$hidden_value = str_replace( '{username}', $replacement, $hidden_value );
 			$hidden_value = str_replace( '{user_nice_name}', $replacement, $hidden_value );
 			$hidden_value = str_replace( '{user_type}', $replacement, $hidden_value );

--- a/includes/widgets-public/widget_actions_base.php
+++ b/includes/widgets-public/widget_actions_base.php
@@ -140,4 +140,36 @@ abstract class Widget_Actions_Base {
 		}
 		return false;
 	}
+
+	/**
+	 * Replace magic tags in hidden field.
+	 *
+	 * @param string $hidden_value Field hidden value
+	 *
+	 * @return string
+	 */
+	protected function parse_hidden_text( $hidden_value ) {
+		global $wp;
+		$current_url = home_url( $wp->request );
+
+		$hidden_value = str_replace( '{current_url}', $current_url, $hidden_value );
+
+		$user_id = get_current_user_id();
+		if ( $user_id !== 0 ){
+			$user_info    = get_userdata( $user_id );
+			$hidden_value = str_replace( '{username}', $user_info->user_login, $hidden_value );
+			$hidden_value = str_replace( '{user_nice_name}', $user_info->first_name . ' ' . $user_info->last_name, $hidden_value );
+			$hidden_value = str_replace( '{user_type}', implode(', ', $user_info->roles), $hidden_value );
+			$hidden_value = str_replace( '{user_email}',  $user_info->user_email, $hidden_value );
+		} else {
+			$replacement = __( 'Could not retrieve the info because the user is not logged id', 'textdomain' );
+			$hidden_value = str_replace( '{username}', $replacement, $hidden_value );
+			$hidden_value = str_replace( '{user_nice_name}', $replacement, $hidden_value );
+			$hidden_value = str_replace( '{user_type}', $replacement, $hidden_value );
+			$hidden_value = str_replace( '{user_email}',  $replacement, $hidden_value );
+		}
+
+		return $hidden_value;
+	}
+
 }

--- a/includes/widgets-public/widget_actions_base.php
+++ b/includes/widgets-public/widget_actions_base.php
@@ -144,13 +144,15 @@ abstract class Widget_Actions_Base {
 	/**
 	 * Replace magic tags in hidden field.
 	 *
-	 * @param string $hidden_value Field hidden value
+	 * @param string $hidden_value Field hidden value.
+	 * @param int    $post_id      Post id.
 	 *
 	 * @return string
 	 */
-	protected function parse_hidden_text( $hidden_value ) {
-		global $wp;
-		$current_url = home_url( $wp->request );
+	protected function parse_hidden_text( $hidden_value, $post_id ) {
+
+
+		$current_url = get_the_permalink( $post_id );
 
 		$hidden_value = str_replace( '{current_url}', $current_url, $hidden_value );
 


### PR DESCRIPTION
I've added an option to be able to add a hidden input in your form. When you add it, you can set a value for it and you can use the following magic tags {current_url}, {username}, {user_nice_name}, {user_type}, {user_email}. If the user is not logged in, the magic tag is replaced with this text: "Could not retrieve the info because the user is not logged in.".
It works only for contact form widget in Elementor and Beaver Builder.

To test this add a new field when using the contact form widget ( elementor or beaver ) and change its type to hidden https://prnt.sc/s0idye
