### PR TITLE
fix: proper sanitize and escape notification alignment

### DIFF
--- a/includes/widgets-admin/elementor/elementor_widget_base.php
+++ b/includes/widgets-admin/elementor/elementor_widget_base.php
@@ -1066,19 +1066,31 @@ abstract class Elementor_Widget_Base extends Widget_Base {
 	}
 
 	/**
+	 * Sanitize alignment values before rendering.
+	 *
+	 * @param mixed $value The value to sanitize.
+	 *
+	 * @return string
+	 */
+	private function sanitize_alignment( $value ) {
+		return in_array( $value, array( 'left', 'center', 'right' ), true ) ? $value : 'left';
+	}
+
+	/**
 	 * Get style for form notification.
 	 *
 	 * @return string
 	 */
 	public function get_notice_style() {
 		$settings = $this->get_settings_for_display();
+		$notification_alignment = esc_attr( $this->sanitize_alignment( $settings['notification_alignment'] ) );
 
-		$style = 'style="margin-left:0; text-align:' . $settings['notification_alignment'] . '"';
+		$style = 'style="margin-left:0; text-align:' . $notification_alignment . '"';
 		if ( $settings['notification_alignment'] === 'right' ) {
-			$style = 'style="margin-right:0; margin-left:auto; text-align:' . $settings['notification_alignment'] . '"';
+			$style = 'style="margin-right:0; margin-left:auto; text-align:' . $notification_alignment . '"';
 		}
 		if ( $settings['notification_alignment'] === 'center' ) {
-			$style = 'style="margin-left: auto; margin-right: auto; text-align:' . $settings['notification_alignment'] . '"';
+			$style = 'style="margin-left: auto; margin-right: auto; text-align:' . $notification_alignment . '"';
 		}
 
 		return $style;

--- a/includes/widgets-admin/elementor/elementor_widget_manager.php
+++ b/includes/widgets-admin/elementor/elementor_widget_manager.php
@@ -54,6 +54,18 @@ class Elementor_Widget_Manager {
 	}
 
 	/**
+	 * Sanitize the alignment attribute.
+	 *
+	 * @param string $alignment The alignment attribute.
+	 *
+	 * @return string
+	 */
+	private function sanitize_alignment( $alignment ) {
+		$allowed_alignments = array( 'left', 'center', 'right' );
+		return in_array( $alignment, $allowed_alignments ) ? $alignment : 'left';
+	}
+
+	/**
 	 * Search and modify the widget settings.
 	 *
 	 * @param array $elements_data The elements data.
@@ -65,6 +77,9 @@ class Elementor_Widget_Manager {
 				if ( isset( $element['widgetType'] ) && in_array( $element['widgetType'], [ 'content_form_registration', 'content_form_newsletter', 'content_form_contact' ] ) ) {
 					// Modify the settings of the widget
 					$settings = $element['settings'];
+					if ( isset( $settings['notification_alignment'] ) ) {
+						$settings['notification_alignment'] = $this->sanitize_alignment( $settings['notification_alignment'] );
+					}
 					if ( isset( $settings['form_fields'] ) ) {
 						$form_fields = $settings['form_fields'];
 						foreach ( $form_fields as &$field ) {


### PR DESCRIPTION
### Summary
Sanitize and escape values of the notification alignment to prevent value alteration.

Dependency for OBFX needs updating after merge.

Closes: Codeinwp/themeisle#1629